### PR TITLE
Backups for the permissions migration

### DIFF
--- a/app/controllers/operatingsystems_controller.rb
+++ b/app/controllers/operatingsystems_controller.rb
@@ -44,11 +44,4 @@ class OperatingsystemsController < ApplicationController
       process_error
     end
   end
-
-  private
-
-  def find_os(permission = :view_operatingsystems)
-    Operatingsystem.authorized(permission).find(params[:id])
-  end
-  
 end

--- a/lib/tasks/backup.rake
+++ b/lib/tasks/backup.rake
@@ -1,0 +1,39 @@
+namespace :db do
+  desc "Make a dump of your database"
+  task :dump => :environment do
+    config      = Rails.configuration.database_configuration[Rails.env]
+    backup_name = "foreman.#{Time.now.to_i}.sql"
+    case config['adapter']
+    when 'mysql', 'mysql2'
+      mysql_dump(backup_name, config)
+    when 'postgresql'
+      postgres_dump(backup_name, config)
+    else
+      puts 'Your database is not supported by Foreman.' and exit(1)
+    end
+
+    puts "Backup in file #{backup_name}"
+  end
+
+  def mysql_dump(name, config)
+    cmd = "mysqldump #{config['database']} -u #{config['username']} "
+    cmd += " -p#{config['password']} " if config['password'].present?
+    cmd += " -h #{config['host']} "    if config['host'].present?
+    cmd += " -P #{config['port']} "    if config['port'].present?
+    cmd += " > #{name}"
+    system(cmd)
+  end
+
+  def postgres_dump(name, config)
+    cmd = "pg_dump #{config['database']} -U #{config['username']} "
+    cmd += " -W #{config['password']}" if config['password'].present?
+    cmd += " -h #{config['host']} "    if config['host'].present?
+    cmd += " -p #{config['port']} "    if config['port'].present?
+    cmd += " > #{name}"
+    system(cmd)
+  end
+
+  desc 'Import your database dump'
+  task :import_dump => :environment do
+  end
+end


### PR DESCRIPTION
This PR contains the update to the permission migration script that allows the user to create a backup before proceeding in both mysql and postgres, which are the only databases supported by foreman. 

It also removes the method 'find_os' which is never used.
