### PR TITLE
Clone roles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "apipie-rails", "~> 0.0.23"
 gem 'rabl', '>= 0.7.5', '<= 0.9.0'
 gem 'oj'
 gem 'oauth'
+gem 'deep_cloneable'
 gem 'foreigner', '~> 1.4.2'
 
 if RUBY_VERSION =~ /^1\.8/

--- a/app/services/foreman/access_permissions.rb
+++ b/app/services/foreman/access_permissions.rb
@@ -487,7 +487,7 @@ Foreman::AccessControl.map do |map|
   map.security_block :roles do |map|
     map.permission :view_roles,    {:roles => [:index, :auto_complete_search],
                                     :'api/v2/roles' => [:index, :show]}
-    map.permission :create_roles,  {:roles => [:new, :create],
+    map.permission :create_roles,  {:roles => [:new, :create, :clone],
                                     :'api/v2/roles' => [:create]}
     map.permission :edit_roles,    {:roles => [:edit, :update],
                                     :'api/v2/roles' => [:update]}

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -15,8 +15,9 @@
           <%= content_tag(role.builtin? ? 'em' : 'span', role.builtin? ? role.name : link_to_if_authorized(role.name, hash_for_edit_role_path(:id => role))) %>
         </td>
         <td>
-          <% links = [display_link_if_authorized(_("Filters and permissions"), hash_for_filters_path(:role_id => role)),
-                      display_link_if_authorized(_("Add permission"), hash_for_new_filter_path(:role_id => role))] %>
+          <% links = [display_link_if_authorized(_('Filters and permissions'), hash_for_filters_path(:role_id => role)),
+                      display_link_if_authorized(_('Add permission'), hash_for_new_filter_path(:role_id => role)),
+                      display_link_if_authorized(_('Clone'), hash_for_clone_role_path(:id => role))] %>
           <% links.push(display_delete_if_authorized(hash_for_role_path(:id => role), :confirm => (_("Delete %s?") % role.name))) unless role.builtin? %>
           <%= action_buttons(*links) %>
         </td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -207,6 +207,9 @@ Foreman::Application.routes.draw do
       end
     end
     resources :roles, :except => [:show] do
+      member do
+        get 'clone'
+      end
       collection do
         get 'auto_complete_search'
       end

--- a/test/functional/roles_controller_test.rb
+++ b/test/functional/roles_controller_test.rb
@@ -19,7 +19,7 @@ require 'test_helper'
 
 class RolesControllerTest < ActionController::TestCase
 
-  def test_get_index
+  test 'get index' do
     get :index, {}, set_session_user
     assert_response :success
     assert_template 'index'
@@ -31,45 +31,45 @@ class RolesControllerTest < ActionController::TestCase
       :content => 'Manager'
   end
 
-  def test_get_new
+  test 'get new' do
     get :new, {}, set_session_user
     assert_response :success
     assert_template 'new'
   end
 
-  def test_post_new_with_validaton_failure
+  test 'empty name validation' do
     post :create, { :role => {:name => ''}}, set_session_user
 
     assert_response :success
     assert_template 'new'
   end
 
-  def test_get_edit
+  test 'get edit goes to right template' do
     get :edit, {:id => 1}, set_session_user
     assert_response :success
     assert_template 'edit'
     assert_equal Role.find(1), assigns(:role)
   end
 
-  def test_post_edit
-    r = FactoryGirl.create(:role)
-    put :update, {:id => r.id, :role => {:name => 'masterManager'}}, set_session_user
+  test 'put edit updates role' do
+    role = FactoryGirl.create(:role)
+    put :update, {:id => role.id, :role => {:name => 'masterManager'}}, set_session_user
 
     assert_redirected_to roles_path
-    r.reload
-    assert_equal 'masterManager', r.name
+    role.reload
+    assert_equal 'masterManager', role.name
   end
 
-  def test_destroy
-    r = FactoryGirl.build(:role, :name => 'ToBeDestroyed')
-    r.add_permissions! :view_ptables
+  test 'delete destroy removes role' do
+    role = FactoryGirl.build(:role, :name => 'ToBeDestroyed')
+    role.add_permissions! :view_ptables
 
-    delete :destroy, {:id => r}, set_session_user
+    delete :destroy, {:id => role}, set_session_user
     assert_redirected_to roles_path
-    assert_nil Role.find_by_id(r.id)
+    assert_nil Role.find_by_id(role.id)
   end
 
-  def test_destroy_role_in_use
+  test 'roles in use cannot be destroyed' do
     users(:one).roles = [roles(:manager)] # make user one a manager
     delete :destroy, {:id => roles(:manager)}, set_session_user
     assert_redirected_to roles_path
@@ -77,4 +77,15 @@ class RolesControllerTest < ActionController::TestCase
     assert_not_nil Role.find_by_id(roles(:manager).id)
   end
 
+  test 'clone' do
+    role = FactoryGirl.build(:role, :name => 'ToBeDestroyed')
+    role.add_permissions! :view_ptables
+
+    get :clone, { :id => role.id } , set_session_user
+    assert_redirected_to roles_path
+
+    cloned_role = Role.find_by_name("#{role.name}_clone")
+    assert_not_nil cloned_role
+    assert_equal cloned_role.permissions, role.permissions
+  end
 end


### PR DESCRIPTION
This feature allows users to clone roles easily. Roles are deeply cloned
using the gem 'deep_cloneable', so that the associations (permissions
and filters) are cloned as well.
